### PR TITLE
Alma transaction filter

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -69,7 +69,8 @@ namespace alma_authorizenet_payment_reporting
                         await EnsureTableExists(connection, schema);
                         var transactions = GetSettledTransactions(
                             options.FromDate ?? await GetMostRecentTransactionDate(connection) ?? DateTime.Today.AddMonths(-1),
-                            options.ToDate ?? DateTime.Today);
+                            options.ToDate ?? DateTime.Today)
+                            .Where(IsAlmaTransaction);
                         var records = await GetPaymentRecords(transactions);
                         await UpdateDatabase(connection, schema, records);
                         if (options.DryRun) Log($"Got {records.Count} records.");
@@ -90,6 +91,8 @@ namespace alma_authorizenet_payment_reporting
                 )
                 ;
         }
+
+        static bool IsAlmaTransaction(AuthorizeTransaction transaction) => transaction.transaction.order.invoiceNumber.StartsWith("ALMA");
 
         static async Task EnsureTableExists(IDbConnection connection, Schema schema)
         {


### PR DESCRIPTION
To prepare for expanding our use of Authorize.net for other systems besides Alma, this change logs any transactions not tagged with ALMA in the invoice number. Once we have a better sense of what data those systems are putting into the transaction objects, a future enhancement will be processing those transactions into a FeePaymentRecord.

I also included code to log an error whenever an Alma transaction is missing the User Id, rather than assuming it will always be there.